### PR TITLE
Fixes for OpenLane PnR files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ dkms.conf
 *.out
 *.vvp
 
+# PnR runs
+PnR/openlane/runs

--- a/PnR/openlane/base.sdc
+++ b/PnR/openlane/base.sdc
@@ -2,7 +2,7 @@
 # Created by write_sdc
 # Tue Apr 25 10:55:41 2023
 ###############################################################################
-current_design por_rosc
+current_design MS_CLK_RST
 ###############################################################################
 # Timing Constraints
 ###############################################################################
@@ -14,7 +14,9 @@ set_false_path -from [get_ports {one}]
 set_false_path -from [get_ports {zero}]
 
 create_clock -name CLK -period 5 [get_pins PoR.ROSC_CLKBUF_1/X]
-create_clock -name CLK_500kHz -period 200 [get_pins _424_/Q]
+set CLK_500kHz_pin [get_pins -of_objects {PoR.clk_div[8]} -filter lib_pin_name==Q]
+puts $CLK_500kHz_pin
+create_clock -name CLK_500kHz -period 200 $CLK_500kHz_pin
 
 set_clock_groups \
    -name clock_group \
@@ -22,7 +24,7 @@ set_clock_groups \
    -group [get_clocks {CLK}]\
    -group [get_clocks {CLK_500kHz}]
 
-set_clock_uncertainty 0.250 [all_clocks] 
+set_clock_uncertainty 0.250 [all_clocks]
 set_propagated_clock [all_clocks]
 
 ###############################################################################

--- a/PnR/openlane/base.sdc
+++ b/PnR/openlane/base.sdc
@@ -15,7 +15,6 @@ set_false_path -from [get_ports {zero}]
 
 create_clock -name CLK -period 5 [get_pins PoR.ROSC_CLKBUF_1/X]
 set CLK_500kHz_pin [get_pins -of_objects {PoR.clk_div[8]} -filter lib_pin_name==Q]
-puts $CLK_500kHz_pin
 create_clock -name CLK_500kHz -period 200 $CLK_500kHz_pin
 
 set_clock_groups \

--- a/PnR/openlane/config.json
+++ b/PnR/openlane/config.json
@@ -2,10 +2,10 @@
     "DESIGN_NAME": "MS_CLK_RST",
     "DESIGN_IS_CORE": false,
     "VERILOG_FILES": [
-        "/home/hosni/ML-SOC/MS_CLK_RST/hdl/rtl/MS_CLK_RST.v",
-        "/home/hosni/ML-SOC/MS_CLK_RST/hdl/rtl/por_rosc.v",
-        "/home/hosni/ML-SOC/MS_CLK_RST/hdl/rtl/clkmux.v",
-        "/home/hosni/ML-SOC/MS_CLK_RST/hdl/rtl/rst_sync.v"
+        "dir::../../hdl/rtl/MS_CLK_RST.v",
+        "dir::../../hdl/rtl/por_rosc.v",
+        "dir::../../hdl/rtl/clkmux.v",
+        "dir::../../hdl/rtl/rst_sync.v"
     ],
     "RUN_LINTER": false,
     "SYNTH_READ_BLACKBOX_LIB": true,
@@ -14,7 +14,7 @@
     "CLOCK_PORT": "",
     "FP_SIZING": "relative",
     "FP_CORE_UTIL": 50,
-    "FP_PDN_AUTO_ADJUST": true, 
+    "FP_PDN_AUTO_ADJUST": true,
     "FP_PDN_VPITCH": 30,
     "FP_PDN_HPITCH": 30,
     "MAX_TRANSITION_CONSTRAINT": 1.5,
@@ -29,7 +29,7 @@
     "MAGIC_DEF_LABELS": false,
     "SYNTH_ABC_BUFFERING": false,
     "RUN_HEURISTIC_DIODE_INSERTION": true,
-    "HEURISTIC_ANTENNA_THRESHOLD": 110,    
+    "HEURISTIC_ANTENNA_THRESHOLD": 110,
     "GRT_REPAIR_ANTENNAS": false,
     "VDD_NETS": [
         "vccd1"

--- a/PnR/openlane/signoff.sdc
+++ b/PnR/openlane/signoff.sdc
@@ -2,7 +2,7 @@
 # Created by write_sdc
 # Tue Apr 25 10:55:41 2023
 ###############################################################################
-current_design por_rosc
+current_design MS_CLK_RST
 ###############################################################################
 # Timing Constraints
 ###############################################################################
@@ -14,7 +14,8 @@ set_false_path -from [get_ports {one}]
 set_false_path -from [get_ports {zero}]
 
 create_clock -name CLK -period 5 [get_pins PoR.ROSC_CLKBUF_1/X]
-create_clock -name CLK_500kHz -period 200 [get_pins _424_/Q]
+set CLK_500kHz_pin [get_pins -of_objects {PoR.clk_div[8]} -filter lib_pin_name==Q]
+create_clock -name CLK_500kHz -period 200 $CLK_500kHz_pin
 
 set_clock_groups \
    -name clock_group \


### PR DESCRIPTION
config.json:
- Make `VERILOG_FILES` paths relative to design directory 

base.sdc:
- Correct `current_design` design name
- Search for `CLK_500kHz` clock port based on `PoR.clk_div[8]` net instead of having a hardcoded cell name

signoff.sdc:
- Search for `CLK_500kHz` clock port based on `PoR.clk_div[8]` net instead of having a hardcoded cell name

misc:
- Remove trailing white spaces in the files above
- Add openlane run folder to `.gitignore`